### PR TITLE
ARM Architecture targets and point to dev branches in upstream repos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,19 +65,29 @@ The ENTR runtime contains the following preinstalled components: OpenOA, entr_wa
 
 Changes to the warehouse may require re-running dbt. To do this:
 
-1. Open a terminal from Jupyter (File > New > Terminal) and navigate to the location where your dbt project is installed (see section "Assumed Repository Structure" section below) using `cd ~/src/entr_warehouse` and run `dbt debug` to test your connection to the Spark warehouse.
-2. Once the connection to the warehouse is confirmed, install the dbt packages for your project using `dbt deps`
-3. Seed the metadata tables contained in the entr_warehouse repo using `dbt seed` to instantiate them in the Spark warehouse
-4. (Re-)register example or newly added source data files with `dbt run-operation stage_external_sources`
-5. Run `dbt run` to build all models in the Spark warehouse, which can now be consumed by any application connected to the Spark warehouse such as OpenOA
+1. Start hive server. From a terminal in Jupyter, start the process:
+```
+/usr/local/spark/bin/spark-submit\
+    --conf spark.hive.server2.thrift.bind.host=localhost\
+    --conf spark.sql.warehouse.dir=/home/jovyan/warehouse\
+    --conf spark.hadoop.javax.jdo.option.ConnectionURL=jdbc:derby:\;databaseName=/home/jovyan/warehouse/metastore_db\;create=true\
+    --class org.apache.spark.sql.hive.thriftserver.HiveThriftServer2
+```
+2. Open a new terminal from Jupyter (File > New > Terminal) and navigate to the location where your dbt project is installed (see section "Assumed Repository Structure" section below) using `cd ~/src/entr_warehouse` and run `dbt debug` to test your connection to the Spark warehouse.
+3. Once the connection to the warehouse is confirmed, install the dbt packages for your project using `dbt deps`
+4. Seed the metadata tables contained in the entr_warehouse repo using `dbt seed` to instantiate them in the Spark warehouse
+5. (Re-)register example or newly added source data files with `dbt run-operation stage_external_sources`
+6. Run `dbt run` to build all models in the Spark warehouse, which can now be consumed by any application connected to the Spark warehouse such as OpenOA
 
 ## Building the entr_runtime image
 
 In most cases, we recommend using the pre-built entr_runtime image avaialble from the github container registry (see quickstart). If you need to rebuild the image yourself, navigate to the entr_runtime directory and run:
 
 ```
-docker build -t entralliance/entr-runtime:dev docker
+docker build -t myname/entr-runtime:dev docker
 ```
+
+In this case, we are specifying that the name of the image will be `myname/entr-runtime`, and the version tag will be be `dev`. You will probably want to modify the name and the tag to suit your own workflow.
 
 ### Running the entr runtime container
 

--- a/README.md
+++ b/README.md
@@ -65,14 +65,7 @@ The ENTR runtime contains the following preinstalled components: OpenOA, entr_wa
 
 Changes to the warehouse may require re-running dbt. To do this:
 
-1. Start hive server. From a terminal in Jupyter, start the process:
-```
-/usr/local/spark/bin/spark-submit\
-    --conf spark.hive.server2.thrift.bind.host=localhost\
-    --conf spark.sql.warehouse.dir=/home/jovyan/warehouse\
-    --conf spark.hadoop.javax.jdo.option.ConnectionURL=jdbc:derby:\;databaseName=/home/jovyan/warehouse/metastore_db\;create=true\
-    --class org.apache.spark.sql.hive.thriftserver.HiveThriftServer2
-```
+1. Start hive server. From a terminal, start the process: `start_hive2.sh`
 2. Open a new terminal from Jupyter (File > New > Terminal) and navigate to the location where your dbt project is installed (see section "Assumed Repository Structure" section below) using `cd ~/src/entr_warehouse` and run `dbt debug` to test your connection to the Spark warehouse.
 3. Once the connection to the warehouse is confirmed, install the dbt packages for your project using `dbt deps`
 4. Seed the metadata tables contained in the entr_warehouse repo using `dbt seed` to instantiate them in the Spark warehouse

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,26 +6,29 @@ FROM jupyter/all-spark-notebook:python-3.9.12
 
 # Warehouse
 ARG ENTR_WAREHOUSE_GIT_URL=https://github.com/entralliance/entr_warehouse.git
-ARG ENTR_WAREHOUSE_GIT_BRANCH=feature/sep22-jan23_public_warehouse_changes
+ARG ENTR_WAREHOUSE_GIT_BRANCH=dev
 
 # OpenOA
 ARG OPENOA_GIT_URL=https://github.com/entralliance/OpenOA.git
-ARG OPENOA_GIT_BRANCH=feature/multiproject_aep
+ARG OPENOA_GIT_BRANCH=dev
 
 ## -------------------------------------------------------------------------------
 ## SECTION: initial setup & package updates
 USER root
 RUN apt-get update && \
-    apt-get -y upgrade && \
-    apt-get install -y libsasl2-modules-gssapi-heimdal && \
-    apt-get install -y libsasl2-dev
+#    apt-get -y upgrade && \
+
+    apt-get install -y libsasl2-modules-gssapi-heimdal libsasl2-dev
 
 ## -------------------------------------------------------------------------------
 ## SECTION: Install and configure Python packages (including DBT)
 USER jovyan
-RUN conda install -c conda-forge sasl &&\
-    pip install pandas matplotlib xgboost numpy xgboost scikit-learn scipy dbt-spark[PyHive]==1.3 sasl &&\
-    mkdir /home/jovyan/.dbt -p &&\
+RUN pip install pandas matplotlib xgboost numpy xgboost scikit-learn scipy dbt-spark[PyHive]==1.3
+
+## -------------------------------------------------------------------------------
+## SECTION: copy local files and grant permissions
+USER jovyan
+RUN mkdir /home/jovyan/.dbt -p &&\
     mkdir /home/jovyan/src/OpenOA -p &&\
     mkdir /home/jovyan/src/entr_warehouse -p &&\
     mkdir /home/jovyan/warehouse -p
@@ -33,16 +36,6 @@ RUN conda install -c conda-forge sasl &&\
 # copy profiles where dbt can find it
 COPY build_profiles.yml /home/jovyan/.dbt/profiles.yml
 
-RUN pwd
-
-# Install and configure OpenOA
-WORKDIR /home/jovyan/src/OpenOA
-RUN git clone --depth 1 --branch ${OPENOA_GIT_BRANCH} ${OPENOA_GIT_URL} . && \
-    rm -rf .git &&\
-    pip install -e .
-
-## -------------------------------------------------------------------------------
-## SECTION: copy local files and grant permissions
 USER root
 
 # grant permissions so that thrift server can create the metastore_db directory
@@ -53,12 +46,14 @@ COPY start_hive2.sh /usr/local/bin
 RUN chmod +x /usr/local/bin/start_hive2.sh
 
 ## -------------------------------------------------------------------------------
-## SECTION: Install and configure entr-warehouse
+## SECTION: Install entr-warehouse
 USER jovyan
 WORKDIR /home/jovyan/src/entr_warehouse
 ENV DBT_PROJECT_PATH=/home/jovyan/src/entr_warehouse
 RUN git clone --depth 1 --branch ${ENTR_WAREHOUSE_GIT_BRANCH} ${ENTR_WAREHOUSE_GIT_URL} . && \
     rm -rf .git
+
+# Initialize the warehouse with example data #TODO: Should we have the user do this?
 RUN bash /usr/local/bin/start_hive2.sh &&\
     sleep 60 &&\
     dbt debug &&\
@@ -66,6 +61,15 @@ RUN bash /usr/local/bin/start_hive2.sh &&\
     dbt seed &&\
     dbt run-operation stage_external_sources &&\
     dbt run
+
+## -------------------------------------------------------------------------------
+## SECTION: Install and configure OpenOA
+# Install and configure OpenOA
+USER jovyan
+WORKDIR /home/jovyan/src/OpenOA 
+RUN git clone --depth 1 --branch ${OPENOA_GIT_BRANCH} ${OPENOA_GIT_URL} . && \
+    rm -rf .git &&\
+    pip install -e .
 
 # -------------------------------------------------------------------------------
 # SECTION: Entry Point

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,11 +6,11 @@ FROM jupyter/all-spark-notebook:python-3.9.12
 
 # Warehouse
 ARG ENTR_WAREHOUSE_GIT_URL=https://github.com/entralliance/entr_warehouse.git
-ARG ENTR_WAREHOUSE_GIT_BRANCH=v0.0.1
+ARG ENTR_WAREHOUSE_GIT_BRANCH=feature/sep22-jan23_public_warehouse_changes
 
 # OpenOA
 ARG OPENOA_GIT_URL=https://github.com/entralliance/OpenOA.git
-ARG OPENOA_GIT_BRANCH=v3.0rc1-entr0.0.2
+ARG OPENOA_GIT_BRANCH=feature/multiproject_aep
 
 ## -------------------------------------------------------------------------------
 ## SECTION: initial setup & package updates
@@ -24,7 +24,7 @@ RUN apt-get update && \
 ## SECTION: Install and configure Python packages (including DBT)
 USER jovyan
 RUN conda install -c conda-forge sasl &&\
-    pip install pandas matplotlib xgboost numpy sklearn xgboost sklearn scipy dbt-spark[PyHive]==1.3 sasl &&\
+    pip install pandas matplotlib xgboost numpy xgboost scikit-learn scipy dbt-spark[PyHive]==1.3 sasl &&\
     mkdir /home/jovyan/.dbt -p &&\
     mkdir /home/jovyan/src/OpenOA -p &&\
     mkdir /home/jovyan/src/entr_warehouse -p &&\


### PR DESCRIPTION
This pull request incorporates several changes which have yet to be merged into the dev branch:

- Better documentation around how to manually launch the Hive server.
- Switched order that image is built, so OpenOA comes after the warehouse, this makes rebuilding the image much quicker in those cases where the warehouse doesn't need to be regenerated.
- Removed conda install sasl statement, which appears to no longer be needed, and which doesn't have an ARM version. 
- Switched repo branch to dev for both OpenOA and the entr_warehouse. This should allow us to perform regular builds from the dev branch.